### PR TITLE
Join Aliasing

### DIFF
--- a/lib/baby_squeel/association.rb
+++ b/lib/baby_squeel/association.rb
@@ -1,43 +1,33 @@
 require 'baby_squeel/table'
 
 module BabySqueel
-  class AliasingError < StandardError
-    MESSAGE =
-      'Attempted to alias \'%{association}\' as \'%{alias_name}\', but the ' \
-      'association was implicitly joined. Either join the association ' \
-      'with `on` or remove the alias.'.freeze
-
-    def initialize(association, alias_name)
-      super format(MESSAGE, association: association, alias_name: alias_name)
-    end
-  end
-
   class Association < Table
+    class AliasingError < StandardError
+      MESSAGE =
+        'Attempted to alias \'%{association}\' as \'%{alias_name}\', but the ' \
+        'association was implicitly joined. Either join the association ' \
+        'with `on` or remove the alias.'.freeze
+
+      def initialize(association, alias_name)
+        super format(MESSAGE, association: association, alias_name: alias_name)
+      end
+    end
+
+    attr_reader :_reflection
+
     def initialize(parent, reflection)
       @parent = parent
-      @reflection = reflection
-      super(@reflection.klass)
+      @_reflection = reflection
+      super(@_reflection.klass)
     end
 
-    def _arel
-      props[:on] ? super : ([*@parent._arel] + join_constraints)
-    end
-
-    private
-
-    def join_constraints
-      if props[:table].is_a? Arel::Nodes::TableAlias
-        raise AliasingError.new(@reflection.name, props[:table].right)
-      end
-
-      @reflection.active_record.joins(@reflection.name).join_sources.map do |join|
-        props[:join].new(join.left, join.right)
-      end
-    end
-
-    def spawn
-      Association.new(@parent, @reflection).tap do |table|
-        table.props = props
+    def _arel(associations = [])
+      if _on
+        super()
+      elsif _table.is_a? Arel::Nodes::TableAlias
+        raise AliasingError.new(_reflection.name, _table.right)
+      else
+        @parent._arel([self, *associations])
       end
     end
   end

--- a/spec/baby_squeel/table_spec.rb
+++ b/spec/baby_squeel/table_spec.rb
@@ -1,9 +1,17 @@
 require 'spec_helper'
 require 'baby_squeel/table'
+require 'shared_examples/table'
 
 describe BabySqueel::Table do
   subject(:table) {
     BabySqueel::Table.new(Post)
+  }
+
+  let(:association) {
+    BabySqueel::Association.new(
+      BabySqueel::Table.new(Author),
+      Author.reflect_on_association(:posts)
+    )
   }
 
   include_examples 'a table'

--- a/spec/shared_examples/table.rb
+++ b/spec/shared_examples/table.rb
@@ -7,6 +7,14 @@ shared_examples_for 'a table' do
     end
   end
 
+  describe '#outer' do
+    it 'does not mutate the original instance' do
+      next_table = table.outer
+      expect(table._join).to eq(Arel::Nodes::InnerJoin)
+      expect(next_table._join).to eq(Arel::Nodes::OuterJoin)
+    end
+  end
+
   describe '#association' do
     it 'builds a table from the associated class' do
       expect(table.association(:author)).to be_a(BabySqueel::Table)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -6,6 +6,7 @@ end
 class Post < ActiveRecord::Base
   has_many :comments
   belongs_to :author
+  has_many :author_comments, through: :author, source: :comments
 end
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
Problem

```ruby
Post.joining { author.posts }
```
```sql
SELECT "posts".* FROM "posts"
INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
INNER JOIN "posts" ON "posts"."author_id" = "authors"."id" -- This is wrong
```

It should be:

```sql
SELECT "posts".* FROM "posts"
INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
INNER JOIN "posts" "posts_authors" ON "posts_authors"."author_id" = "authors"
```

Basically, ActiveRecord needs to build the join from the root of the association in order to alias correctly.