### PR TITLE
Extend arel nodes with some extra functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - More descriptive error messages when a column or association is not found.
 
+### Fixed
+- `Arel::Nodes::Grouping` does not include `Arel::Math`, so operations like `(id + 5) + 3` would fail unexpectedly.
+
 ## [0.2.1] - 2015-03-27
 ### Added
 - Support for subqueries.

--- a/lib/baby_squeel/nodes.rb
+++ b/lib/baby_squeel/nodes.rb
@@ -60,13 +60,22 @@ module BabySqueel
     # include necessary/applicable modules.
     class Generic < Proxy
       extend Operators::ArelAliasing
-      include Arel::AliasPredication
-      include Arel::OrderPredications
       include Operators::Comparison
       include Operators::Equality
       include Operators::Generic
       include Operators::Grouping
       include Operators::Matching
+
+      # Extend the Arel node with some extra modules. For example,
+      # Arel::Nodes::Grouping does not implement Math. InfixOperation doesn't
+      # implement AliasPredication. Without these extensions, the interface
+      # just seems inconsistent.
+      def initialize(node)
+        node.extend Arel::Math
+        node.extend Arel::AliasPredication
+        node.extend Arel::OrderPredications
+        super(node)
+      end
     end
 
     class Attribute < Generic

--- a/spec/baby_squeel/nodes/generic_spec.rb
+++ b/spec/baby_squeel/nodes/generic_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'baby_squeel/nodes'
 
 describe BabySqueel::Nodes::Generic do
+  subject(:node) {
+    described_class.new(Post.arel_table[:id])
+  }
+
   describe 'included modules' do
     subject { described_class.ancestors }
     specify { is_expected.to include(BabySqueel::Operators::Comparison) }
@@ -9,5 +13,9 @@ describe BabySqueel::Nodes::Generic do
     specify { is_expected.to include(BabySqueel::Operators::Generic) }
     specify { is_expected.to include(BabySqueel::Operators::Grouping) }
     specify { is_expected.to include(BabySqueel::Operators::Matching) }
+  end
+
+  it 'extends any node with math' do
+    expect((node + 5) * 5).to produce_sql('("posts"."id" + 5) * 5')
   end
 end


### PR DESCRIPTION
`Arel::Nodes::Grouping` does not include `Arel::Math`, so operations like `(id + 5) + 3` would fail unexpectedly. Extending Arel instances with methods that you'd expect to be there feels like the best solution. The alternative fixes would be to:

1. Globally include Arel::Math for each arel node that doesn't implement this functionality, but I'd really rather not do this.
2. Manually implement each method, wrapping the result in a new proxy. This is okay, but also would require a lot more redundant code.