### PR TITLE
Tables without models

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ authors = Author.selecting { name.op('||', quoted('-dizzle')).as('swag') }
 authors.first.swag #=> 'Ray Zane-dizzle'
 ```
 
+##### Querying tables without Active Record models
+
+```ruby
+table = BabySqueel[:some_table]
+
+Post.joining {
+  table.on(table.post_id == id)
+}.where.has {
+  table.some_column == 1
+}
+```
+
 ## Sifters
 
 Sifters are like little snippets of conditions that can take arguments.

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -4,20 +4,22 @@ require 'baby_squeel/version'
 require 'baby_squeel/active_record'
 
 module BabySqueel
-  def self.configure
-    yield self
-  end
+  class << self
+    def configure
+      yield self
+    end
 
-  def self.enable_compatibility!
-    require 'baby_squeel/compat'
-    BabySqueel::Compat.enable!
-  end
+    def enable_compatibility!
+      require 'baby_squeel/compat'
+      BabySqueel::Compat.enable!
+    end
 
-  def self.[](thing)
-    if thing.respond_to?(:model_name)
-      Relation.new(thing)
-    else
-      Table.new(Arel::Table.new(thing))
+    def [](thing)
+      if thing.respond_to?(:model_name)
+        Relation.new(thing)
+      else
+        Table.new(Arel::Table.new(thing))
+      end
     end
   end
 

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require 'active_record/relation'
 require 'baby_squeel/version'
+require 'baby_squeel/errors'
 require 'baby_squeel/active_record'
 
 module BabySqueel
@@ -20,18 +21,6 @@ module BabySqueel
       else
         Table.new(Arel::Table.new(thing))
       end
-    end
-  end
-
-  class NotFoundError < StandardError
-    def initialize(model_name, name)
-      super "There is no column or association named '#{name}' for #{model_name}."
-    end
-  end
-
-  class AssociationNotFoundError < StandardError
-    def initialize(model_name, name)
-      super "Association named '#{name}' was not found for #{model_name}."
     end
   end
 end

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -12,6 +12,18 @@ module BabySqueel
     require 'baby_squeel/compat'
     BabySqueel::Compat.enable!
   end
+
+  class NotFoundError < StandardError
+    def initialize(model_name, name)
+      super "There is no column or association named '#{name}' for #{model_name}."
+    end
+  end
+
+  class AssociationNotFoundError < StandardError
+    def initialize(model_name, name)
+      super "Association named '#{name}' was not found for #{model_name}."
+    end
+  end
 end
 
 ::ActiveRecord::Base.extend BabySqueel::ActiveRecord::Sifting

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -13,6 +13,14 @@ module BabySqueel
     BabySqueel::Compat.enable!
   end
 
+  def self.[](thing)
+    if thing.respond_to?(:model_name)
+      Relation.new(thing)
+    else
+      Table.new(Arel::Table.new(thing))
+    end
+  end
+
   class NotFoundError < StandardError
     def initialize(model_name, name)
       super "There is no column or association named '#{name}' for #{model_name}."

--- a/lib/baby_squeel/association.rb
+++ b/lib/baby_squeel/association.rb
@@ -1,7 +1,7 @@
-require 'baby_squeel/table'
+require 'baby_squeel/relation'
 
 module BabySqueel
-  class Association < Table
+  class Association < Relation
     class AliasingError < StandardError
       MESSAGE =
         'Attempted to alias \'%{association}\' as \'%{alias_name}\', but the ' \

--- a/lib/baby_squeel/association.rb
+++ b/lib/baby_squeel/association.rb
@@ -2,17 +2,6 @@ require 'baby_squeel/relation'
 
 module BabySqueel
   class Association < Relation
-    class AliasingError < StandardError
-      MESSAGE =
-        'Attempted to alias \'%{association}\' as \'%{alias_name}\', but the ' \
-        'association was implicitly joined. Either join the association ' \
-        'with `on` or remove the alias.'.freeze
-
-      def initialize(association, alias_name)
-        super format(MESSAGE, association: association, alias_name: alias_name)
-      end
-    end
-
     attr_reader :_reflection
 
     def initialize(parent, reflection)
@@ -37,7 +26,7 @@ module BabySqueel
       if _on
         super
       elsif _table.is_a? Arel::Nodes::TableAlias
-        raise AliasingError.new(_reflection.name, _table.right)
+        raise AssociationAliasingError.new(_reflection.name, _table.right)
       else
         @parent._arel([self, *associations])
       end

--- a/lib/baby_squeel/dsl.rb
+++ b/lib/baby_squeel/dsl.rb
@@ -1,9 +1,9 @@
 require 'baby_squeel/nodes'
-require 'baby_squeel/table'
+require 'baby_squeel/relation'
 require 'baby_squeel/association'
 
 module BabySqueel
-  class DSL < Table
+  class DSL < Relation
     class << self
       # Evaluates a block and unwraps the nodes
       def evaluate(scope, &block)

--- a/lib/baby_squeel/errors.rb
+++ b/lib/baby_squeel/errors.rb
@@ -1,0 +1,24 @@
+module BabySqueel
+  class NotFoundError < StandardError
+    def initialize(model_name, name)
+      super "There is no column or association named '#{name}' for #{model_name}."
+    end
+  end
+
+  class AssociationNotFoundError < StandardError
+    def initialize(model_name, name)
+      super "Association named '#{name}' was not found for #{model_name}."
+    end
+  end
+
+  class AssociationAliasingError < StandardError
+    MESSAGE =
+      'Attempted to alias \'%{association}\' as \'%{alias_name}\', but the ' \
+      'association was implicitly joined. Either join the association ' \
+      'with `on` or remove the alias.'.freeze
+
+    def initialize(association, alias_name)
+      super format(MESSAGE, association: association, alias_name: alias_name)
+    end
+  end
+end

--- a/lib/baby_squeel/join_dependency.rb
+++ b/lib/baby_squeel/join_dependency.rb
@@ -9,14 +9,14 @@ module BabySqueel
 
     if ActiveRecord::VERSION::STRING < '4.1.0'
       def bind_values
+        return [] unless relation?
         _scope.joins(join_names(@associations)).bind_values
       end
     else
       def bind_values
-        @bind_values ||= begin
-          relation = _scope.joins(join_names(@associations))
-          relation.arel.bind_values + relation.bind_values
-        end
+        return [] unless relation?
+        relation = _scope.joins(join_names(@associations))
+        relation.arel.bind_values + relation.bind_values
       end
     end
 
@@ -28,7 +28,7 @@ module BabySqueel
     def _arel
       if _on
         [_join.new(_table, _on)]
-      else
+      elsif relation?
         @associations.each.with_index.inject([]) do |joins, (assoc, i)|
           construct @associations[0..i], joins, assoc._join
         end
@@ -36,6 +36,10 @@ module BabySqueel
     end
 
     private
+
+    def relation?
+      @table.kind_of? BabySqueel::Relation
+    end
 
     def construct(associations, theirs, join_node)
       names = join_names associations

--- a/lib/baby_squeel/join_dependency.rb
+++ b/lib/baby_squeel/join_dependency.rb
@@ -28,7 +28,7 @@ module BabySqueel
     def _arel
       if _on
         [_join.new(_table, _on)]
-      elsif relation?
+      else
         @associations.each.with_index.inject([]) do |joins, (assoc, i)|
           construct @associations[0..i], joins, assoc._join
         end

--- a/lib/baby_squeel/nodes.rb
+++ b/lib/baby_squeel/nodes.rb
@@ -94,10 +94,12 @@ module BabySqueel
       end
 
       def _arel
-        parent_arel = @parent._arel._arel
+        parent_arel = @parent._arel
+        parent_arel &&= parent_arel._arel
+        parent_arel &&= parent_arel.last
 
-        if parent_arel && parent_arel.last
-          parent_arel.last.left[@name]
+        if parent_arel
+          parent_arel.left[@name]
         else
           super
         end

--- a/lib/baby_squeel/operators.rb
+++ b/lib/baby_squeel/operators.rb
@@ -10,7 +10,7 @@ module BabySqueel
       #
       # ==== Example
       #    BabySqueel::Nodes::Generic.arel_alias :unlike, :does_not_match
-      #    Post.where { title.unlike 'something' }
+      #    Post.where.has { title.unlike 'something' }
       #
       def arel_alias(operator, arel_name)
         define_method operator do |other|
@@ -42,7 +42,7 @@ module BabySqueel
       # * +other+ - The argument to be passed to the SQL operator.
       #
       # ==== Example
-      #    Post.select { title.op('||', quoted('diddly')) }
+      #    Post.selecting { title.op('||', quoted('diddly')) }
       #    #=> SELECT "posts"."title" || 'diddly' FROM "posts"
       #
       def op(operator, other)

--- a/lib/baby_squeel/relation.rb
+++ b/lib/baby_squeel/relation.rb
@@ -1,0 +1,42 @@
+require 'baby_squeel/table'
+
+module BabySqueel
+  class Relation < Table
+    attr_accessor :_scope
+
+    def initialize(scope)
+      super(scope.arel_table)
+      @_scope = scope
+    end
+
+    # @override BabySqueel::Table#_table_name
+    def _table_name
+      _scope.model_name
+    end
+
+    # Constructs a new BabySqueel::Association. Raises
+    # an exception if the association is not found.
+    def association(name)
+      if reflection = _scope.reflect_on_association(name)
+        Association.new(self, reflection)
+      else
+        raise AssociationNotFoundError.new(_table_name, name)
+      end
+    end
+
+    def sift(sifter_name, *args)
+      Nodes.wrap _scope.public_send("sift_#{sifter_name}", *args)
+    end
+
+    private
+
+    # @override BabySqueel::Table#resolve
+    def resolve(name)
+      if _scope.column_names.include?(name.to_s)
+        self[name]
+      elsif _scope.reflect_on_association(name)
+        association(name)
+      end
+    end
+  end
+end

--- a/lib/baby_squeel/table.rb
+++ b/lib/baby_squeel/table.rb
@@ -66,6 +66,7 @@ module BabySqueel
     # 2. Resolve the assocition's join clauses using ActiveRecord.
     #
     def _arel(associations = [])
+      return unless _on || associations.any?
       JoinDependency.new(self, associations)
     end
 

--- a/spec/baby_squeel/active_record/query_methods/joining_spec.rb
+++ b/spec/baby_squeel/active_record/query_methods/joining_spec.rb
@@ -269,13 +269,13 @@ describe BabySqueel::ActiveRecord::QueryMethods, '#joining' do
     it 'raises an error when attempting to alias an inner join' do
       expect {
         Post.joining { author.alias('a') }.to_sql
-      }.to raise_error(BabySqueel::Association::AliasingError, /'author' as 'a'/)
+      }.to raise_error(BabySqueel::AssociationAliasingError, /'author' as 'a'/)
     end
 
     it 'raises an error when attempting to alias an outer join' do
       expect {
         Post.joining { author.outer.alias('a') }.to_sql
-      }.to raise_error(BabySqueel::Association::AliasingError, /'author' as 'a'/)
+      }.to raise_error(BabySqueel::AssociationAliasingError, /'author' as 'a'/)
     end
   end
 end

--- a/spec/baby_squeel/active_record/where_chain_spec.rb
+++ b/spec/baby_squeel/active_record/where_chain_spec.rb
@@ -130,5 +130,18 @@ describe BabySqueel::ActiveRecord::WhereChain do
         WHERE "authors"."id" IN (SELECT "authors"."id" FROM "authors" LIMIT 3)
       EOSQL
     end
+
+    it 'wheres using a simple table' do
+      simple = BabySqueel[:authors]
+      relation = Post.joins(:author).where.has {
+        simple.name == 'Yo Gotti'
+      }
+
+      expect(relation).to produce_sql(<<-EOSQL)
+        SELECT "posts".* FROM "posts"
+        INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
+        WHERE "authors"."name" = 'Yo Gotti'
+      EOSQL
+    end
   end
 end

--- a/spec/baby_squeel/association_spec.rb
+++ b/spec/baby_squeel/association_spec.rb
@@ -5,7 +5,7 @@ require 'shared_examples/table'
 describe BabySqueel::Association do
   subject(:table) {
     BabySqueel::Association.new(
-      BabySqueel::Table.new(Author),
+      BabySqueel::Relation.new(Author),
       Author.reflect_on_association(:posts)
     )
   }

--- a/spec/baby_squeel/dsl_spec.rb
+++ b/spec/baby_squeel/dsl_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 require 'shared_examples/table'
+require 'shared_examples/relation'
 require 'baby_squeel/dsl'
 
 describe BabySqueel::DSL do
   subject(:dsl) {
     BabySqueel::DSL.new(Post)
   }
+
+  it_behaves_like 'a relation' do
+    subject(:table) { dsl }
+  end
 
   it_behaves_like 'a table' do
     subject(:table) { dsl }

--- a/spec/baby_squeel/nodes/attribute_spec.rb
+++ b/spec/baby_squeel/nodes/attribute_spec.rb
@@ -5,7 +5,7 @@ require 'baby_squeel/table'
 describe BabySqueel::Nodes::Attribute do
   subject(:attribute) {
     described_class.new(
-      BabySqueel::Table.new(Post),
+      BabySqueel::Relation.new(Post),
       :id
     )
   }

--- a/spec/baby_squeel/relation_spec.rb
+++ b/spec/baby_squeel/relation_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'baby_squeel/relation'
+require 'shared_examples/table'
+require 'shared_examples/relation'
+
+describe BabySqueel::Relation do
+  subject(:table) {
+    BabySqueel::Relation.new(Post)
+  }
+
+  include_examples 'a table'
+  include_examples 'a relation'
+end

--- a/spec/baby_squeel/table_spec.rb
+++ b/spec/baby_squeel/table_spec.rb
@@ -4,7 +4,9 @@ require 'shared_examples/table'
 
 describe BabySqueel::Table do
   subject(:table) {
-    BabySqueel::Relation.new(Post)
+    BabySqueel::Table.new(
+      Arel::Table.new(:posts)
+    )
   }
 
   include_examples 'a table'

--- a/spec/baby_squeel/table_spec.rb
+++ b/spec/baby_squeel/table_spec.rb
@@ -4,7 +4,7 @@ require 'shared_examples/table'
 
 describe BabySqueel::Table do
   subject(:table) {
-    BabySqueel::Table.new(Post)
+    BabySqueel::Relation.new(Post)
   }
 
   include_examples 'a table'

--- a/spec/baby_squeel_spec.rb
+++ b/spec/baby_squeel_spec.rb
@@ -1,4 +1,13 @@
 require 'spec_helper'
 
 describe BabySqueel do
+  describe '.[]' do
+    it 'accepts a model' do
+      expect(BabySqueel[Post]).to be_a(BabySqueel::Relation)
+    end
+
+    it 'accepts a symbol' do
+      expect(BabySqueel[:posts]).to be_a(BabySqueel::Table)
+    end
+  end
 end

--- a/spec/shared_examples/relation.rb
+++ b/spec/shared_examples/relation.rb
@@ -1,0 +1,37 @@
+shared_examples_for 'a relation' do
+  describe '#respond_to?' do
+    it 'resolves associations' do
+      is_expected.to respond_to(:author)
+    end
+  end
+
+  describe '#association' do
+    it 'builds a table from the associated class' do
+      expect(table.association(:author)).to be_a(BabySqueel::Table)
+    end
+
+    it 'allows chaining attributes' do
+      assoc = table.association :author
+      expect(assoc.id).to be_a(Arel::Attributes::Attribute)
+    end
+
+    it 'raises an error for non-existant associations' do
+      expect {
+        table.association :non_existent
+      }.to raise_error(
+        BabySqueel::AssociationNotFoundError,
+        /named 'non_existent'(.+)for Post/
+      )
+    end
+  end
+
+  describe '#method_missing' do
+    it 'resolves associations' do
+      expect(table.author).to be_a(BabySqueel::Table)
+    end
+
+    it 'raises a custom error for things that look like columns' do
+      expect { table.non_existent_column }.to raise_error(BabySqueel::NotFoundError)
+    end
+  end
+end

--- a/spec/shared_examples/table.rb
+++ b/spec/shared_examples/table.rb
@@ -15,33 +15,9 @@ shared_examples_for 'a table' do
     end
   end
 
-  describe '#association' do
-    it 'builds a table from the associated class' do
-      expect(table.association(:author)).to be_a(BabySqueel::Table)
-    end
-
-    it 'allows chaining attributes' do
-      assoc = table.association :author
-      expect(assoc.id).to be_a(Arel::Attributes::Attribute)
-    end
-
-    it 'raises an error for non-existant associations' do
-      expect {
-        table.association :non_existent
-      }.to raise_error(
-        BabySqueel::AssociationNotFoundError,
-        /named 'non_existent'(.+)for Post/
-      )
-    end
-  end
-
   describe '#respond_to?' do
     it 'resolves attributes' do
       is_expected.to respond_to(:title)
-    end
-
-    it 'resolves associations' do
-      is_expected.to respond_to(:author)
     end
   end
 
@@ -50,16 +26,8 @@ shared_examples_for 'a table' do
       expect(table.id).to be_an(Arel::Attributes::Attribute)
     end
 
-    it 'resolves associations' do
-      expect(table.author).to be_a(BabySqueel::Table)
-    end
-
     it 'does not resolve when a block is given' do
       expect { table.id { 'block' } }.to raise_error(NameError)
-    end
-
-    it 'raises a custom error for things that look like columns' do
-      expect { table.non_existent_column }.to raise_error(BabySqueel::NotFoundError)
     end
   end
 end


### PR DESCRIPTION
Sometimes, like in the case of a HABTM relationship, you might want to join and query on a table that doesn't have a model.

Now, you can do this:

```ruby
table = BabySqueel[:some_table]

Post.joining {
  table.on(table.post_id == id)
}.where.has {
  table.some_column == 1
}
```