### PR TITLE
Fix ActiveRecord 5 deprecations when using Arel::Table directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
     - AR=4.0.0
     - AR=4.1.15
     - AR=4.2.6
-    - AR=5.0.0.rc1
+    - AR=5.0.0
 
     - AR=4.0.0 COMPAT=1
     - AR=4.1.15 COMPAT=1
     - AR=4.2.6 COMPAT=1
-    - AR=5.0.0.rc1 COMPAT=1
+    - AR=5.0.0 COMPAT=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Changed
 - Arel nodes are only extended with the behaviors they need. Previously, all Arel nodes were being extended with `Arel::AliasPredication`, `Arel::OrderPredications`, and `Arel::Math`.
 
+### Fixed
+- Fixed deprecation warnings on Active Record 5 when initializing an Arel::Table without a type caster.
+
 ## [0.3.1] - 2016-08-02
 ### Added
 - Ported backticks and #my from Squeel

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -15,11 +15,13 @@ module BabySqueel
       BabySqueel::Compat.enable!
     end
 
-    def [](thing)
+    def [](thing, **kwargs)
       if thing.respond_to?(:model_name)
         Relation.new(thing)
+      elsif thing.kind_of?(Arel::Table)
+        Table.new(thing)
       else
-        Table.new(Arel::Table.new(thing))
+        Table.new(Arel::Table.new(thing, **kwargs))
       end
     end
   end

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -132,7 +132,12 @@ describe BabySqueel::ActiveRecord::WhereChain do
     end
 
     it 'wheres using a simple table' do
-      simple = BabySqueel[:authors]
+      simple = if Arel::VERSION > '7.0.0'
+                 BabySqueel[:authors, type_caster: Author.type_caster]
+               else
+                 BabySqueel[:authors]
+               end
+
       relation = Post.joins(:author).where.has {
         simple.name == 'Yo Gotti'
       }


### PR DESCRIPTION
See: https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11