### PR TITLE
Use strings for attribute names like Rails does

### DIFF
--- a/lib/baby_squeel/nodes/attribute.rb
+++ b/lib/baby_squeel/nodes/attribute.rb
@@ -5,8 +5,8 @@ module BabySqueel
     class Attribute < Node
       def initialize(parent, name)
         @parent = parent
-        @name = name
-        super(parent._table[name])
+        @name = name.to_s
+        super(parent._table[@name])
       end
 
       def in(rel)

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -231,4 +231,12 @@ describe BabySqueel::ActiveRecord::WhereChain do
       EOSQL
     end
   end
+
+  describe '#where_values_hash' do
+    it 'returns the same hash that Rails normally would' do
+      squeel = Author.where.has{id == 123}
+      rails = Author.where(id: 123)
+      expect(squeel.where_values_hash).to eq(rails.where_values_hash)
+    end
+  end
 end


### PR DESCRIPTION
Symbols were preventing things like unscope from working.

I wasn't sure where to put this test case, hope this is okay.