### PR TITLE
where should accept nil

### DIFF
--- a/lib/baby_squeel/active_record/where_chain.rb
+++ b/lib/baby_squeel/active_record/where_chain.rb
@@ -5,7 +5,8 @@ module BabySqueel
     module WhereChain
       # Constructs Arel for ActiveRecord::Base#where using the DSL.
       def has(&block)
-        @scope.where! DSL.evaluate(@scope, &block)
+        arel = DSL.evaluate(@scope, &block)
+        @scope.where!(arel) unless arel.nil?
         @scope
       end
     end

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -13,6 +13,14 @@ describe BabySqueel::ActiveRecord::WhereChain do
       EOSQL
     end
 
+    it 'accepts nil' do
+      relation = Post.where.has { nil }
+
+      expect(relation).to produce_sql(<<-EOSQL)
+        SELECT "posts".* FROM "posts"
+      EOSQL
+    end
+
     it 'wheres on associations' do
       relation = Post.joins(:author).where.has {
         author.name == 'Yo Gotti'


### PR DESCRIPTION
In Active Record, `where(nil)` just ignores the where condition. Currently, `where.has { nil }` will throw an error:

```
Unsupported argument type:  (NilClass)
```

This is definitely incorrect behavior.


