### PR TITLE
Query association equality

### DIFF
--- a/lib/baby_squeel/association.rb
+++ b/lib/baby_squeel/association.rb
@@ -20,6 +20,14 @@ module BabySqueel
       end
     end
 
+    def ==(other)
+      Nodes.wrap build_where_clause(other).ast
+    end
+
+    def !=(other)
+      Nodes.wrap build_where_clause(other).invert.ast
+    end
+
     def of(klass)
       unless _reflection.polymorphic?
         raise PolymorphicSpecificationError.new(_reflection.name, klass)
@@ -84,6 +92,14 @@ module BabySqueel
       else
         @parent._arel([self, *associations])
       end
+    end
+
+    private
+
+    def build_where_clause(other)
+      relation = @parent._scope.where(nil)
+      factory = relation.send(:where_clause_factory)
+      factory.build({ _reflection.name => other }, [])
     end
   end
 end

--- a/lib/baby_squeel/association.rb
+++ b/lib/baby_squeel/association.rb
@@ -2,6 +2,9 @@ require 'baby_squeel/relation'
 
 module BabySqueel
   class Association < Relation
+    class InvalidComparisonError < StandardError
+    end
+
     # An Active Record association reflection
     attr_reader :_reflection
 
@@ -96,10 +99,34 @@ module BabySqueel
 
     private
 
-    def build_where_clause(other)
-      relation = @parent._scope.where(nil)
-      factory = relation.send(:where_clause_factory)
-      factory.build({ _reflection.name => other }, [])
+    if ActiveRecord::VERSION::MAJOR >= 5
+      def build_where_clause(other)
+        if valid_where_clause?(other)
+          relation = @parent._scope.where(nil)
+          factory = relation.send(:where_clause_factory)
+          factory.build({ _reflection.name => other }, [])
+        else
+          raise InvalidComparisonError, <<-EOMSG.squish
+            You can't compare association '#{_reflection.name}'
+            to #{other.class}.
+          EOMSG
+        end
+      end
+    else
+      def build_where_clause(_)
+        raise NotImplementedError, <<-EOMSG.squish
+          Querying association '#{_reflection.name}' with '==' and '!='
+          is only supported for ActiveRecord 5.
+        EOMSG
+      end
+    end
+
+    def valid_where_clause?(other)
+      if other.respond_to? :all?
+        other.all? { |o| valid_where_clause? o }
+      else
+        other.nil? || other.respond_to?(:model_name)
+      end
     end
   end
 end

--- a/spec/baby_squeel/association_spec.rb
+++ b/spec/baby_squeel/association_spec.rb
@@ -33,6 +33,12 @@ describe BabySqueel::Association do
   end
 
   describe '#==' do
+    before do
+      if ActiveRecord::VERSION::MAJOR < 5
+        skip "This isn't supported in ActiveRecord 4"
+      end
+    end
+
     it 'returns an wrapped Arel::Nodes::And' do
       node = association == Author.new(id: 42)
       expect(node._arel.left).to be_an(Arel::Nodes::Equality)
@@ -46,6 +52,12 @@ describe BabySqueel::Association do
   end
 
   describe '#!=' do
+    before do
+      if ActiveRecord::VERSION::MAJOR < 5
+        skip "This isn't supported in ActiveRecord 4"
+      end
+    end
+
     it 'returns some wrapped arel' do
       node = association != Author.new(id: 42)
       expect(node._arel.left.expr).to be_an(Arel::Nodes::NotEqual)

--- a/spec/baby_squeel/association_spec.rb
+++ b/spec/baby_squeel/association_spec.rb
@@ -32,6 +32,32 @@ describe BabySqueel::Association do
     end
   end
 
+  describe '#==' do
+    it 'returns an wrapped Arel::Nodes::And' do
+      node = association == Author.new(id: 42)
+      expect(node._arel.left).to be_an(Arel::Nodes::Equality)
+    end
+
+    it 'throws for an invalid comparison' do
+      expect {
+        association == 'foo'
+      }.to raise_error(BabySqueel::Association::InvalidComparisonError)
+    end
+  end
+
+  describe '#!=' do
+    it 'returns some wrapped arel' do
+      node = association != Author.new(id: 42)
+      expect(node._arel.left.expr).to be_an(Arel::Nodes::NotEqual)
+    end
+
+    it 'throws for an invalid comparison' do
+      expect {
+        association != 'foo'
+      }.to raise_error(BabySqueel::Association::InvalidComparisonError)
+    end
+  end
+
   describe '#add_to_tree' do
     def make_tree(tree_node)
       hash = {}

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -238,6 +238,30 @@ describe BabySqueel::ActiveRecord::WhereChain do
         )
       EOSQL
     end
+
+    it 'wheres an association using #==' do
+      author = Author.new(id: 42)
+      relation = Post.where.has do |post|
+        post.author == author
+      end
+
+      expect(relation).to produce_sql(<<-EOSQL)
+        SELECT "posts".* FROM "posts"
+        WHERE ("posts"."author_id" = 42)
+      EOSQL
+    end
+
+    it 'wheres an association using #!=' do
+      author = Author.new(id: 42)
+      relation = Post.where.has do |post|
+        post.author != author
+      end
+
+      expect(relation).to produce_sql(<<-EOSQL)
+        SELECT "posts".* FROM "posts"
+        WHERE (("posts"."author_id" != 42))
+      EOSQL
+    end
   end
 
   describe '#where_values_hash' do

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -240,6 +240,10 @@ describe BabySqueel::ActiveRecord::WhereChain do
     end
 
     it 'wheres an association using #==' do
+      if ActiveRecord::VERSION::MAJOR < 5
+        skip "This isn't supported in ActiveRecord 4"
+      end
+
       author = Author.new(id: 42)
       relation = Post.where.has do |post|
         post.author == author
@@ -252,6 +256,10 @@ describe BabySqueel::ActiveRecord::WhereChain do
     end
 
     it 'wheres an association using #!=' do
+      if ActiveRecord::VERSION::MAJOR < 5
+        skip "This isn't supported in ActiveRecord 4"
+      end
+
       author = Author.new(id: 42)
       relation = Post.where.has do |post|
         post.author != author

--- a/spec/shared_examples/table.rb
+++ b/spec/shared_examples/table.rb
@@ -15,7 +15,7 @@ shared_examples_for 'a table' do
     end
 
     it 'does not mutate the original instance' do
-      expect(table.on(expr)).not_to eq(table)
+      expect(table.on(expr).object_id).not_to eq(table.object_id)
     end
   end
 
@@ -25,7 +25,7 @@ shared_examples_for 'a table' do
     end
 
     it 'does not mutate the original instance' do
-      expect(table.inner).not_to eq(table)
+      expect(table.inner.object_id).not_to eq(table.object_id)
     end
   end
 
@@ -35,7 +35,7 @@ shared_examples_for 'a table' do
     end
 
     it 'does not mutate the original instance' do
-      expect(table.outer).not_to eq(table)
+      expect(table.outer.object_id).not_to eq(table.object_id)
     end
   end
 


### PR DESCRIPTION
Example:

```ruby
Post.where.has { author == Author.last }
Post.where.has { author != Author.last }
```

**Note:** This is only supported in ActiveRecord 5+

Closes #43