### PR TITLE
Attribute#in should always return a BabySqueel::Node.

### DIFF
--- a/lib/baby_squeel/nodes/attribute.rb
+++ b/lib/baby_squeel/nodes/attribute.rb
@@ -11,7 +11,8 @@ module BabySqueel
 
       def in(rel)
         if rel.is_a? ::ActiveRecord::Relation
-          ::Arel::Nodes::In.new(self, Arel.sql(rel.to_sql))
+          expr = ::Arel.sql(rel.to_sql)
+          Nodes.wrap ::Arel::Nodes::In.new(self, expr)
         else
           super
         end

--- a/spec/baby_squeel/nodes/attribute_spec.rb
+++ b/spec/baby_squeel/nodes/attribute_spec.rb
@@ -34,6 +34,11 @@ describe BabySqueel::Nodes::Attribute do
         "posts"."id" IN (SELECT "posts"."id" FROM "posts" LIMIT 3)
       EOSQL
     end
+
+    it 'returns a BabySqueel node' do
+      relation = Post.select(:id)
+      expect(attribute.in(relation)).to respond_to(:_arel)
+    end
   end
 
   describe '#not_in' do


### PR DESCRIPTION
Previously, it was returning a normal Arel expression, but that's definitely not what we want.

Fixes #61 