### PR TITLE
Allow plucking to accept an array

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,11 +60,13 @@ end
 desc 'Watch for changes and rerun specs'
 task 'spec:watch' do
   puts 'Watching...'
-  FileWatcher.new(['lib', 'spec']).watch do |filename|
-    if filename =~ /_spec\.rb$/
-      system "bundle exec rspec #{filename}"
-    else
-      system 'bundle exec rspec'
+  Filewatcher.new(['lib', 'spec']).watch do |filename|
+    Bundler.with_clean_env do
+      if filename =~ /_spec\.rb$/
+        system "bundle exec rspec #{filename}"
+      else
+        system 'bundle exec rspec'
+      end
     end
   end
 end
@@ -74,7 +76,9 @@ Bump::Bump::BUMPS.each do |bump|
   task "release:#{bump}" => "bump:#{bump}" do
     # we can't just run this as a prereq, because gem_tasks
     # loads the version when rake loads
-    sh 'rake release'
+    Bundler.with_clean_env do
+      sh 'bundle exec rake release'
+    end
   end
 end
 

--- a/lib/baby_squeel/active_record/calculations.rb
+++ b/lib/baby_squeel/active_record/calculations.rb
@@ -5,7 +5,9 @@ module BabySqueel
   module ActiveRecord
     module Calculations
       def plucking(&block)
-        pluck Pluck.wrap(DSL.evaluate(self, &block))
+        nodes = Array.wrap(DSL.evaluate(self, &block))
+        nodes = nodes.map { |node| Pluck.decorate(node) }
+        pluck(*nodes)
       end
 
       def counting(&block)

--- a/lib/baby_squeel/pluck.rb
+++ b/lib/baby_squeel/pluck.rb
@@ -9,9 +9,9 @@ module BabySqueel
     # bother to use this there.
 
     if ::ActiveRecord::VERSION::MAJOR >= 5
-      def self.wrap(node); node; end
+      def self.decorate(node); node; end
     else
-      def self.wrap(node); new(node); end
+      def self.decorate(node); new(node); end
     end
 
     def initialize(node)

--- a/spec/baby_squeel/pluck_spec.rb
+++ b/spec/baby_squeel/pluck_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe BabySqueel::Pluck do
-  describe '.wrap' do
+  describe '.decorate' do
     if ActiveRecord::VERSION::MAJOR >= 5
       it 'always returns identity' do
-        expect(described_class.wrap(1)).to eq(1)
+        expect(described_class.decorate(1)).to eq(1)
       end
     else
-      it 'returns a CalculationProxy' do
-        expect(described_class.new(1)).to be_a(described_class)
+      it 'returns a Pluck' do
+        expect(described_class.decorate(1)).to be_a(described_class)
       end
     end
   end

--- a/spec/integration/plucking_spec.rb
+++ b/spec/integration/plucking_spec.rb
@@ -14,6 +14,11 @@ describe '#plucking' do
     expect(result).to match_array(['one', 'two'])
   end
 
+  it 'plucks with array' do
+    result = Post.plucking { [title] }
+    expect(result).to match_array(['one', 'two'])
+  end
+
   it 'plucks distinct' do
     result = Post.distinct.plucking { view_count }
     expect(result).to match_array([1])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ require 'support/matchers'
 require 'support/factories'
 require 'support/query_tracker'
 
+ActiveSupport::Deprecation.behavior = :raise
+
 RSpec.configure do |config|
   config.include Factories
   config.include QueryTracker


### PR DESCRIPTION
I thought this was a bug, but as it turns out, plucking an array wasn't previously supported.