### PR TITLE
Use table strategy for undefined associations in Squeel Compatibility mode

### DIFF
--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4.0'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.13' # see https://github.com/rails/rails/issues/35153
 end

--- a/lib/baby_squeel/compat.rb
+++ b/lib/baby_squeel/compat.rb
@@ -64,6 +64,12 @@ module BabySqueel
         @caller = block.binding.eval('self')
         super
       end
+
+      private
+
+      def resolver
+        @resolver ||= BabySqueel::Resolver.new(self, [:function, :column, :association, :table])
+      end
     end
 
     module QueryMethods

--- a/lib/baby_squeel/resolver.rb
+++ b/lib/baby_squeel/resolver.rb
@@ -57,6 +57,8 @@ module BabySqueel
         @table.association(name)
       when :column, :attribute
         @table[name]
+      when :table
+        Table.new(Arel::Table.new(name))
       end
     end
 
@@ -71,7 +73,7 @@ module BabySqueel
         @table._scope.column_names.include?(name.to_s)
       when :association
         !@table._scope.reflect_on_association(name).nil?
-      when :function, :attribute
+      when :function, :attribute, :table
         true
       end
     end
@@ -82,7 +84,7 @@ module BabySqueel
       case strategy
       when :function
         !args.empty?
-      when :column, :attribute, :association
+      when :column, :attribute, :association, :table
         args.empty?
       end
     end

--- a/spec/shared_examples/relation.rb
+++ b/spec/shared_examples/relation.rb
@@ -31,6 +31,9 @@ shared_examples_for 'a relation' do
     end
 
     it 'raises a custom error for things that look like columns' do
+      if ENV['COMPAT']
+        skip "This isn't supported in Squeel Compatibility mode"
+      end
       expect { table.non_existent_column }.to raise_error(BabySqueel::NotFoundError)
     end
   end


### PR DESCRIPTION
Hi,

This PR makes migrating from squeel easier by falling back to "table strategy" when referencing undefined associations (same behavior as squeel.)