### PR TITLE
Add .on method to Arel::Node::TableAlias for subquery alias joins

### DIFF
--- a/lib/arel/nodes/table_alias.rb
+++ b/lib/arel/nodes/table_alias.rb
@@ -1,0 +1,6 @@
+class Arel::Nodes::TableAlias
+  def on(node = nil, &block)
+    table = BabySqueel::Table.new(self)
+    table.on(node, &block)
+  end
+end


### PR DESCRIPTION
I was running into a situation on a production app where we were doing a join on a subquery, and we were getting an `undefined method 'on' for Arel::Node::TableAlias` with the following structure:

```ruby
# Query 1
subquery = Foo.joins(:bar).select('DISTINCT ON (foo.id) foo_id, bar.timestamp').order('foo.id, bar.timestamp DESC')

# Query 2
Foo.distinct.joining{ |foo| subquery.as('foo_subquery').on { foo_id == foo.id }.outer }
```

I added this patch, and that allowed the second query to proceed and generate the correct SQL to hit the database. I thought it would be helpful to create a pull request, especially as it appears that this might be what was trying to be done in #46?