### PR TITLE
Mostly fix integration with Active Record 5.2.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,19 @@ else
   gem 'activerecord', ENV['AR']
 end
 
+case ENV.fetch('RANSACK', 'latest')
+when 'latest'
+  gem 'ransack', require: false
+when 'master'
+  gem 'ransack', github: 'activerecord-hackery/ransack', require: false
+else
+  ENV['RANSACK'].split('#').tap do |repo, branch|
+    opts = {git: repo, require: false}
+    opts[:branch] = branch if branch
+    gem 'ransack', opts
+  end
+end
+
 gem 'bump'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,6 @@ else
   gem 'activerecord', ENV['AR']
 end
 
-git 'https://github.com/gregmolnar/ransack', branch: 'fix-polymorphic-joins' do
-  gem 'polyamorous'
-end
-
 gem 'bump'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ group :test do
   gem 'coveralls'
   gem 'simplecov'
   gem 'filewatcher'
+  gem 'byebug'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,10 @@ else
   gem 'activerecord', ENV['AR']
 end
 
+git 'https://github.com/activerecord-hackery/ransack', branch: 'master' do
+  gem 'polyamorous'
+end
+
 gem 'bump'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ else
   gem 'activerecord', ENV['AR']
 end
 
-git 'https://github.com/activerecord-hackery/ransack', branch: 'master' do
+git 'https://github.com/gregmolnar/ransack', branch: 'fix-polymorphic-joins' do
   gem 'polyamorous'
 end
 

--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
   spec.add_dependency 'activerecord', '>= 4.2.0'
-  spec.add_dependency 'polyamorous', '~> 2.3.0'
+  spec.add_dependency 'ransack', '~> 2.3'
   spec.add_dependency 'join_dependency', '~> 0.1.4'
 
   spec.add_development_dependency 'bundler', '~> 2'

--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
   spec.add_dependency 'activerecord', '>= 4.2.0'
-  spec.add_dependency 'polyamorous', '~> 2.1.1'
+  spec.add_dependency 'polyamorous', '~> 2.3.0'
   spec.add_dependency 'join_dependency', '~> 0.1.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'

--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
   spec.add_dependency 'activerecord', '>= 4.2.0'
-  spec.add_dependency 'polyamorous', '~> 1.3'
-  spec.add_dependency 'join_dependency', '~> 0.1.2'
+  spec.add_dependency 'polyamorous', '~> 2.1.1'
+  spec.add_dependency 'join_dependency', '~> 0.1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4.0'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -1,6 +1,11 @@
 require 'active_record'
 require 'active_record/relation'
-require 'polyamorous'
+begin
+  require 'polyamorous'
+rescue LoadError
+  # Trying loading from 'ransack' as of commit c9cc20de9 (post v2.3.2)
+  require 'polyamorous/polyamorous'
+end
 require 'baby_squeel/version'
 require 'baby_squeel/errors'
 require 'baby_squeel/active_record/base'

--- a/lib/baby_squeel/join_dependency.rb
+++ b/lib/baby_squeel/join_dependency.rb
@@ -35,8 +35,13 @@ module BabySqueel
       # a list (in order of chaining) of associations and finding
       # the respective JoinAssociation at each level.
       def find_alias(associations)
-        table = find_join_association(associations).table
-        reconstruct_with_type_caster(table, associations)
+        join_association = find_join_association(associations)
+
+        if join_association.table
+          join_association.table
+        else
+          join_association.base_klass.arel_table
+        end
       end
 
       private
@@ -62,16 +67,6 @@ module BabySqueel
       # In AR5, #parent_reflection returns just a reflection
       def comparable_reflection(reflection)
         [*reflection.parent_reflection].last || reflection
-      end
-
-      # Active Record 5's AliasTracker initializes Arel tables
-      # with the type_caster belonging to the wrong model.
-      #
-      # See: https://github.com/rails/rails/pull/27994
-      def reconstruct_with_type_caster(table, associations)
-        return table if ::ActiveRecord::VERSION::MAJOR < 5
-        type_caster = associations.last._scope.type_caster
-        ::Arel::Table.new(table.name, type_caster: type_caster)
       end
     end
   end

--- a/lib/baby_squeel/join_dependency.rb
+++ b/lib/baby_squeel/join_dependency.rb
@@ -37,9 +37,15 @@ module BabySqueel
       def find_alias(associations)
         join_association = find_join_association(associations)
 
+        # NOTE: Below is a hack. It does not work. In previous
+        # versions of Active Record, `#table` would ALWAYS return
+        # an instance of Arel::Table.
         if join_association.table
           join_association.table
         else
+          # This literally does not work. This will often
+          # give you the wrong Arel::Table instance, which
+          # causes aliases in the query to be wrong.
           join_association.base_klass.arel_table
         end
       end

--- a/lib/baby_squeel/join_dependency.rb
+++ b/lib/baby_squeel/join_dependency.rb
@@ -47,24 +47,15 @@ module BabySqueel
       private
 
       def find_join_association(associations)
-        join_root = join_dependency.send(:join_root)
-        steps = associations.map {|a| a._reflection.name}
-        association_from_steps(join_root, steps)
-      end
-
-      # Search depth-first through the descendants of +current+ for successive
-      # associations in +steps+.
-      #
-      # Each generation of descent consumes one element of +steps+.
-      def association_from_steps(current, steps)
-        return current if steps.empty?
-        matching_assoc = nil
-        current.children.each do |child|
-          next unless child.reflection.name == steps.first
-          matching_assoc = association_from_steps(child, steps[1..-1])
-          break if matching_assoc
+        current = join_dependency.send(:join_root)
+        
+        associations.each do |association|
+          name = association._reflection.name
+          current = current.children.find { |c| c.reflection.name == name }
+          break if current.nil?
         end
-        matching_assoc
+        
+        current
       end
     end
   end

--- a/lib/baby_squeel/table.rb
+++ b/lib/baby_squeel/table.rb
@@ -9,7 +9,6 @@ module BabySqueel
 
     def initialize(arel_table)
       @_table = arel_table
-      @_accumulated_associations = {}
     end
 
     # See Arel::Table#[]
@@ -85,13 +84,7 @@ module BabySqueel
     # This method allows BabySqueel::Nodes::Attribute
     # instances to find what their alias will be.
     def find_alias(associations = [])
-      this_arel = _arel(associations)
-      if this_arel.kind_of?(Hash)
-        _accumulate_associations(@_accumulated_associations, this_arel)
-        rel = _scope.joins @_accumulated_associations
-      else
-        rel = _scope.joins this_arel
-      end
+      rel = _scope.joins _arel(associations)
       builder = JoinDependency::Builder.new(rel)
       builder.find_alias(associations)
     end
@@ -129,13 +122,6 @@ module BabySqueel
 
     def method_missing(*args, &block)
       resolver.resolve!(*args, &block) || super
-    end
-    
-    def _accumulate_associations(dest, source)
-      source.each_pair do |k, v|
-        dest[k] ||= {}
-        _accumulate_associations(dest[k], v)
-      end
     end
   end
 end

--- a/spec/integration/__snapshots__/joining_spec.yaml
+++ b/spec/integration/__snapshots__/joining_spec.yaml
@@ -18,8 +18,8 @@
 "#joining when joining explicitly aliases after the on clause 1": SELECT "posts".*
   FROM "posts" INNER JOIN "authors" "a" ON "authors"."id" = "posts"."author_id"
 "#joining when joining explicitly merges bind values 1": SELECT "posts".* FROM "posts"
-  INNER JOIN "authors" ON "authors"."ugly" = 't' AND "authors"."id" = "posts"."author_id"
-  INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
+  INNER JOIN "authors" ON "authors"."id" = "posts"."author_id" AND "authors"."ugly"
+  = 't' INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
 "#joining when joining explicitly with complex conditions inner joins 1": SELECT "posts".*
   FROM "posts" INNER JOIN "authors" ON ("posts"."author_id" = "authors"."id" AND "authors"."id"
   != 5 OR "authors"."name" IS NULL)
@@ -91,3 +91,6 @@
 : SELECT "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
   LEFT OUTER JOIN "comments" ON "comments"."author_id" = "authors"."id" INNER JOIN
   "authors" "authors_posts" ON "authors_posts"."id" = "posts"."author_id"
+"#joining when joining explicitly merges bind values 1 (Active Record: v5.2)": SELECT "posts".* FROM "posts"
+  INNER JOIN "authors" ON "authors"."ugly" = 't' AND "authors"."id" = "posts"."author_id"
+  INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"

--- a/spec/integration/__snapshots__/joining_spec.yaml
+++ b/spec/integration/__snapshots__/joining_spec.yaml
@@ -18,8 +18,8 @@
 "#joining when joining explicitly aliases after the on clause 1": SELECT "posts".*
   FROM "posts" INNER JOIN "authors" "a" ON "authors"."id" = "posts"."author_id"
 "#joining when joining explicitly merges bind values 1": SELECT "posts".* FROM "posts"
-  INNER JOIN "authors" ON "authors"."id" = "posts"."author_id" AND "authors"."ugly"
-  = 't' INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
+  INNER JOIN "authors" ON "authors"."ugly" = 't' AND "authors"."id" = "posts"."author_id"
+  INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
 "#joining when joining explicitly with complex conditions inner joins 1": SELECT "posts".*
   FROM "posts" INNER JOIN "authors" ON ("posts"."author_id" = "authors"."id" AND "authors"."id"
   != 5 OR "authors"."name" IS NULL)

--- a/spec/integration/__snapshots__/joining_spec.yaml
+++ b/spec/integration/__snapshots__/joining_spec.yaml
@@ -91,6 +91,11 @@
 : SELECT "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
   LEFT OUTER JOIN "comments" ON "comments"."author_id" = "authors"."id" INNER JOIN
   "authors" "authors_posts" ON "authors_posts"."id" = "posts"."author_id"
-"#joining when joining explicitly merges bind values 1 (Active Record: v5.2)": SELECT "posts".* FROM "posts"
-  INNER JOIN "authors" ON "authors"."ugly" = 't' AND "authors"."id" = "posts"."author_id"
-  INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
+"#joining when joining explicitly merges bind values 1 (Active Record: v5.2)": SELECT
+  "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."ugly" = 't' AND "authors"."id"
+  = "posts"."author_id" INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
+"#joining when joining implicitly correctly identifies a table independenty joined via separate associations 1": SELECT
+  "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
+  INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" INNER JOIN "authors"
+  "authors_comments" ON "authors_comments"."id" = "comments"."author_id" WHERE
+  "authors_comments"."name" = 'Bob'

--- a/spec/integration/__snapshots__/where_chain_spec.yaml
+++ b/spec/integration/__snapshots__/where_chain_spec.yaml
@@ -94,3 +94,9 @@
   FROM "posts" WHERE "posts"."author_id" = 42
 "#where.has wheres an association using #!= 1 (Active Record: v5.2)": SELECT "posts".*
   FROM "posts" WHERE "posts"."author_id" != 42
+"#where.has wheres on polymorphic associations 1 (Active Record: v5.2)": SELECT "pictures".*
+  FROM "pictures" INNER JOIN "posts" ON "posts"."id" = "pictures"."imageable_id" AND
+  "pictures"."imageable_type" = 'Post' WHERE "posts"."title" LIKE 'meatloaf'
+"#where.has wheres on polymorphic associations outer join 1 (Active Record: v5.2)": SELECT
+  "pictures".* FROM "pictures" LEFT OUTER JOIN "posts" ON "posts"."id" = "pictures"."imageable_id"
+  AND "pictures"."imageable_type" = 'Post' WHERE "posts"."title" LIKE 'meatloaf'

--- a/spec/integration/joining_spec.rb
+++ b/spec/integration/joining_spec.rb
@@ -73,7 +73,7 @@ describe '#joining' do
     it 'merges bind values' do
       relation = Post.joining { ugly_author_comments }
 
-      expect(relation).to match_sql_snapshot
+      expect(relation).to match_sql_snapshot(variants: ['5.2'])
     end
 
     context 'with complex conditions' do

--- a/spec/integration/joining_spec.rb
+++ b/spec/integration/joining_spec.rb
@@ -122,20 +122,12 @@ describe '#joining' do
 
     describe 'polymorphism' do
       it 'inner joins' do
-        if ActiveRecord::VERSION::STRING >= '5.2.0'
-          pending "polyamorous's support for polymorphism is broken"
-        end
-
         relation = Picture.joining { imageable.of(Post) }
 
         expect(relation).to match_sql_snapshot
       end
 
       it 'outer joins' do
-        if ActiveRecord::VERSION::STRING >= '5.2.0'
-          pending "polyamorous's support for polymorphism is broken"
-        end
-
         relation = Picture.joining { imageable.of(Post).outer }
 
         expect(relation).to match_sql_snapshot
@@ -164,10 +156,6 @@ describe '#joining' do
       end
 
       it 'handles polymorphism' do
-        if ActiveRecord::VERSION::STRING >= '5.2.0'
-          pending "polyamorous's support for polymorphism is broken"
-        end
-
         relation = Picture.joining { imageable.of(Post).comments }
 
         expect(relation).to match_sql_snapshot

--- a/spec/integration/joining_spec.rb
+++ b/spec/integration/joining_spec.rb
@@ -284,5 +284,15 @@ describe '#joining' do
         Post.joining { author.outer.alias('a') }.to_sql
       }.to raise_error(BabySqueel::AssociationAliasingError, /'author' as 'a'/)
     end
+
+    it "correctly identifies a table independenty joined via separate associations" do
+      relation = Post
+      relation = relation.joining { [author, comments.author] }
+      relation = relation.where.has {
+        comments.author.name == 'Bob'
+      }
+      
+      expect(relation.to_sql).to match_sql_snapshot
+    end
   end
 end

--- a/spec/integration/where_chain_spec.rb
+++ b/spec/integration/where_chain_spec.rb
@@ -70,27 +70,19 @@ describe '#where.has' do
   end
 
   it 'wheres on polymorphic associations' do
-    if ActiveRecord::VERSION::STRING >= '5.2.0'
-      pending "polyamorous's support for polymorphism is broken"
-    end
-
     relation = Picture.joining { imageable.of(Post) }.where.has {
       imageable.of(Post).title =~ 'meatloaf'
     }
 
-    expect(relation).to match_sql_snapshot
+    expect(relation).to match_sql_snapshot(variants: ['5.2'])
   end
 
   it 'wheres on polymorphic associations outer join' do
-    if ActiveRecord::VERSION::STRING >= '5.2.0'
-      pending "polyamorous's support for polymorphism is broken"
-    end
-
     relation = Picture.joining { imageable.of(Post).outer }.where.has {
       imageable.of(Post).title =~ 'meatloaf'
     }
 
-    expect(relation).to match_sql_snapshot
+    expect(relation).to match_sql_snapshot(variants: ['5.2'])
   end
 
   it 'wheres and correctly aliases' do


### PR DESCRIPTION
The left-join functionality still is showing errors, but I think that those cases are unlikely in existing usage.  Had such code been written, the "`LEFT OUTER`-ness" of the the join would have been compromised back to `INNER`-ness due to subsequent `INNER JOIN`ing discarding the rows where the `LEFT OUTER`-ness introduced `NULL` column values.

I'm happy to edit the test cases (and README) to eliminate these failing cases, or I have a branch with a much more powerful "left joining" syntax in the works.