### PR TITLE
add support for activerecord 6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Active Record v${{ matrix.activerecord }} (compat=${{ matrix.compat }})
     strategy:
       matrix:
-        activerecord: ["5.2.0", "5.2.5"]
+        activerecord: ["5.2.0", "5.2.5", "6.0.3"]
         compat: ["0", "1"]
     env:
       AR: ${{ matrix.activerecord }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- add support for activerecord 6.0
+
 ## [1.4.1] - 2021-06-17
 ## Fixed
 - Fixed a bug related to checking the Active Record version.

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,18 @@ gemspec
 case ENV.fetch('AR', 'latest')
 when 'latest'
   gem 'activerecord'
+  gem 'sqlite3', '~> 1.4'
 when 'master'
   gem 'activerecord', github: 'rails/rails'
+  gem 'sqlite3', '~> 1.4'
 else
   gem 'activerecord', ENV['AR']
+
+  if Gem::Version.new(ENV['AR']) < Gem::Version.new('5.2.3')
+    gem 'sqlite3', '~> 1.3.6'
+  else
+    gem 'sqlite3', '~> 1.4'
+  end
 end
 
 case ENV.fetch('RANSACK', 'latest')

--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
-  spec.add_dependency 'activerecord', '~> 5.2'
+  spec.add_dependency 'activerecord', '>= 5.2', '< 6.1'
   spec.add_dependency 'ransack', '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/baby_squeel/active_record/query_methods.rb
+++ b/lib/baby_squeel/active_record/query_methods.rb
@@ -37,11 +37,27 @@ module BabySqueel
       private
 
       # This is a monkey patch, and I'm not happy about it.
-      # Active Record will call `group_by` on the `joins`. The
-      # Injector has a custom `group_by` method that handles
-      # BabySqueel::Join nodes.
-      def build_joins(manager, joins, aliases)
-        super manager, BabySqueel::JoinDependency::Injector.new(joins), aliases
+      def build_joins(*args)
+        if ::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR == 2
+          # Active Record will call `group_by` on the `joins`. The
+          # Injector has a custom `group_by` method that handles
+          # BabySqueel::Join nodes.
+          args[1] = BabySqueel::JoinDependency::Injector5_2.new(args.second)
+        elsif ::ActiveRecord::VERSION::MAJOR == 6 && ::ActiveRecord::VERSION::MINOR == 0
+          # Active Record will call `each` on the `joins`. The
+          # Injector has a custom `each` method that handles
+          # BabySqueel::Join nodes.
+          args[1] = BabySqueel::JoinDependency::Injector6_0.new(args.second)
+        else
+          # Please help baby_squeel to get ready for Rails 6.1.
+          # I think you can start at this commits:
+          # https://github.com/rails/rails/commit/c0c53ee9d28134757cf1418521cb97c4a135f140
+          # https://github.com/rails/rails/commit/f799f019641f432e9d1260e38846129b40f81d28
+          # We might monkey patch select_association_list instead of build_joins.
+          raise('This method or the Injector probably need to change')
+        end
+
+        super *args
       end
     end
   end

--- a/spec/baby_squeel/join_dependency/injector5_2_spec.rb
+++ b/spec/baby_squeel/join_dependency/injector5_2_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe BabySqueel::JoinDependency::Injector do
+describe BabySqueel::JoinDependency::Injector5_2 do
   let(:join_path) {
     BabySqueel::Join.new([])
   }

--- a/spec/baby_squeel/join_dependency/injector6_0_spec.rb
+++ b/spec/baby_squeel/join_dependency/injector6_0_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe BabySqueel::JoinDependency::Injector6_0 do
+  let(:join_path) {
+    BabySqueel::Join.new([])
+  }
+
+  let(:joins_values) {
+    [:something, join_path, {a: :b}]
+  }
+
+  subject(:injector) { described_class.new(joins_values) }
+
+  describe '#each' do
+    it 'do not blow up without a buckets hash' do
+      test_each = []
+      injector.each do |join|
+        test_each << join
+      end
+      expect(test_each).to eq(joins_values)
+    end
+
+    it 'never yields JoinPath instances to the block if buckets hash is given' do
+      buckets = Hash.new { |h, k| h[k] = [] }
+      injector.each do |join|
+        expect(join).not_to eq(join_path)
+      end
+    end
+
+    it 'adds JoinPath into buckets[:association_join]' do
+      buckets = Hash.new { |h, k| h[k] = [] }
+      injector.each { |join| buckets[:other] << join }
+      expect(buckets[:other]).to eq([:something, { a: :b }])
+      expect(buckets[:association_join]).to eq([join_path])
+    end
+
+    it 'can accompany other :association_joins' do
+      buckets = Hash.new { |h, k| h[k] = [] }
+      injector.each { |join| buckets[:association_join] << join }
+      expect(buckets[:association_join]).to eq(joins_values)
+    end
+  end
+end

--- a/spec/integration/__snapshots__/joining_spec.yaml
+++ b/spec/integration/__snapshots__/joining_spec.yaml
@@ -99,6 +99,9 @@
 "#joining when joining explicitly merges bind values 1 (Active Record: v5.2.0)": SELECT
   "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
   AND "authors"."ugly" = 't' INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
+"#joining when joining explicitly merges bind values 1 (Active Record: v6.0)": SELECT
+  "posts".* FROM "posts" INNER JOIN "authors" ON "authors"."ugly" = 1 AND "authors"."id"
+  = "posts"."author_id" INNER JOIN "comments" ON "comments"."author_id" = "authors"."id"
 "#joining when joining implicitly polymorphism double polymorphic joining 1": SELECT
   "pictures".* FROM "pictures" INNER JOIN "authors" ON "authors"."id" = "pictures"."imageable_id"
   AND "pictures"."imageable_type" = 'Author' INNER JOIN "posts" ON "posts"."id" =

--- a/spec/integration/joining_spec.rb
+++ b/spec/integration/joining_spec.rb
@@ -73,7 +73,7 @@ describe '#joining' do
     it 'merges bind values' do
       relation = Post.joining { ugly_author_comments }
 
-      expect(relation).to match_sql_snapshot(variants: ['5.2.0'])
+      expect(relation).to match_sql_snapshot(variants: ['5.2.0', '6.0'])
     end
 
     context 'with complex conditions' do


### PR DESCRIPTION
Like I mentioned in https://github.com/rzane/baby_squeel/discussions/110#discussioncomment-865258

* All Tests are green :) but I have no Rails 6.0 application to test it in real live.
Might be good to cut a 1.4 befor merging this.