### PR TITLE
Add support for Rails 7.1

### DIFF
--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
-  spec.add_dependency 'activerecord', '>= 6.1.6', '< 7.2'
+  spec.add_dependency 'activerecord', '>= 6.1.5', '< 7.2'
   spec.add_dependency 'ransack', '~> 4.1'
 
   spec.add_development_dependency 'bundler', '~> 2'

--- a/baby_squeel.gemspec
+++ b/baby_squeel.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('{lib/**/*,*.{md,txt,gemspec}}')
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 7.1'
+  spec.add_dependency 'activerecord', '>= 6.1.6', '< 7.2'
   spec.add_dependency 'ransack', '~> 4.1'
 
   spec.add_development_dependency 'bundler', '~> 2'

--- a/lib/baby_squeel/nodes/attribute.rb
+++ b/lib/baby_squeel/nodes/attribute.rb
@@ -41,7 +41,7 @@ module BabySqueel
       # Conveniently, this approach automatically adds a 1=0.
       # I have literally no idea why, but I'll take it.
       def sanitize_relation(rel)
-        if rel.kind_of? ::ActiveRecord::NullRelation
+        if ::ActiveRecord::VERSION::MAJOR < 7 && rel.kind_of?(::ActiveRecord::NullRelation)
           other = rel.spawn
           other.extending_values -= [::ActiveRecord::NullRelation]
           sanitize_relation rel.unscoped.merge(other)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,12 @@ require 'support/matchers'
 require 'support/factories'
 require 'support/query_tracker'
 
-ActiveSupport::Deprecation.behavior = :raise
+if ActiveSupport.respond_to?(:deprecator)
+  ActiveSupport.deprecator.behavior = :raise
+  ActiveRecord.deprecator.behavior = :raise
+else
+  ActiveSupport::Deprecation.behavior = :raise
+end
 
 RSpec.configure do |config|
   config.include Factories


### PR DESCRIPTION
Require ransack >= 4.1 for Rails 7.1 support.

Two major changes in Rails 7.1 are:
- [NullRelation was removed][null_relation], but it seems the behaviour changed in Rails 7.0 such that the special handling was no longer required anyway
- [ActiveSupport::Deprecation singleton was deprecated][deprecation]

[null_relation]: https://github.com/rails/rails/pull/47800
[deprecation]: https://github.com/rails/rails/pull/47354